### PR TITLE
Add support for void HTML tags like `<img>`

### DIFF
--- a/explorer/post-parser.js
+++ b/explorer/post-parser.js
@@ -179,54 +179,67 @@
             type: "HTML_Comment",
             innerText: cs.join('')
           } },
-        peg$c21 = function(s, ct) { return s.name === ct.name },
-        peg$c22 = function(s, children, e) { return s.name === e.name },
-        peg$c23 = function(s, children, e) { return {
+        peg$c21 = function(t) { return undefined !== {
+              'br': true,
+              'col': true,
+              'embed': true,
+              'hr': true,
+              'img': true,
+              'input': true
+            }[ t.name.toLowerCase() ] },
+        peg$c22 = function(t) { return {
+            type: 'HTML_Void_Tag',
+            name: t.name,
+            attrs: t.attrs
+          } },
+        peg$c23 = function(s, ct) { return s.name === ct.name },
+        peg$c24 = function(s, children, e) { return s.name === e.name },
+        peg$c25 = function(s, children, e) { return {
             type: 'HTML_Tag',
             name: s.name,
             attrs: s.attrs,
             children
           } },
-        peg$c24 = "<",
-        peg$c25 = peg$literalExpectation("<", false),
-        peg$c26 = ">",
-        peg$c27 = peg$literalExpectation(">", false),
-        peg$c28 = function(name, attrs) { return {
+        peg$c26 = "<",
+        peg$c27 = peg$literalExpectation("<", false),
+        peg$c28 = ">",
+        peg$c29 = peg$literalExpectation(">", false),
+        peg$c30 = function(name, attrs) { return {
             type: 'HTML_Tag_Open',
             name,
             attrs
           } },
-        peg$c29 = "</",
-        peg$c30 = peg$literalExpectation("</", false),
-        peg$c31 = function(name) { return {
+        peg$c31 = "</",
+        peg$c32 = peg$literalExpectation("</", false),
+        peg$c33 = function(name) { return {
             type: 'HTML_Tag_Close',
             name
           } },
-        peg$c32 = function(a) { return a },
-        peg$c33 = function(as) { return as.reduce( ( attrs, [ name, value ] ) => Object.assign(
+        peg$c34 = function(a) { return a },
+        peg$c35 = function(as) { return as.reduce( ( attrs, [ name, value ] ) => Object.assign(
             attrs,
             { [ name ]: value }
           ), {} ) },
-        peg$c34 = function(name) { return [ name, true ] },
-        peg$c35 = "=",
-        peg$c36 = peg$literalExpectation("=", false),
-        peg$c37 = /^[a-zA-Z0-9]/,
-        peg$c38 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"]], false, false),
-        peg$c39 = function(name, value) { return [ name, value ] },
-        peg$c40 = "\"",
-        peg$c41 = peg$literalExpectation("\"", false),
-        peg$c42 = "'",
-        peg$c43 = peg$literalExpectation("'", false),
-        peg$c44 = /^[a-zA-Z0-9:.]/,
-        peg$c45 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], ":", "."], false, false),
-        peg$c46 = /^[a-zA-Z]/,
-        peg$c47 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c48 = /^[0-9]/,
-        peg$c49 = peg$classExpectation([["0", "9"]], false, false),
-        peg$c50 = /^[\r\n]/,
-        peg$c51 = peg$classExpectation(["\r", "\n"], false, false),
-        peg$c52 = /^[ \t]/,
-        peg$c53 = peg$classExpectation([" ", "\t"], false, false),
+        peg$c36 = function(name) { return [ name, true ] },
+        peg$c37 = "=",
+        peg$c38 = peg$literalExpectation("=", false),
+        peg$c39 = /^[a-zA-Z0-9]/,
+        peg$c40 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"]], false, false),
+        peg$c41 = function(name, value) { return [ name, value ] },
+        peg$c42 = "\"",
+        peg$c43 = peg$literalExpectation("\"", false),
+        peg$c44 = "'",
+        peg$c45 = peg$literalExpectation("'", false),
+        peg$c46 = /^[a-zA-Z0-9:.]/,
+        peg$c47 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], ":", "."], false, false),
+        peg$c48 = /^[a-zA-Z]/,
+        peg$c49 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c50 = /^[0-9]/,
+        peg$c51 = peg$classExpectation([["0", "9"]], false, false),
+        peg$c52 = /^[\r\n]/,
+        peg$c53 = peg$classExpectation(["\r", "\n"], false, false),
+        peg$c54 = /^[ \t]/,
+        peg$c55 = peg$classExpectation([" ", "\t"], false, false),
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -394,34 +407,37 @@
           if (s0 === peg$FAILED) {
             s0 = peg$parseHTML_Comment();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseHTML_Tag_Balanced();
+              s0 = peg$parseHTML_Tag_Void();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseHTML_Tag_Open();
+                s0 = peg$parseHTML_Tag_Balanced();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseHTML_Tag_Close();
+                  s0 = peg$parseHTML_Tag_Open();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    s1 = peg$currPos;
-                    s2 = [];
-                    s3 = peg$parseHTML_Text();
-                    if (s3 !== peg$FAILED) {
-                      while (s3 !== peg$FAILED) {
-                        s2.push(s3);
-                        s3 = peg$parseHTML_Text();
+                    s0 = peg$parseHTML_Tag_Close();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$currPos;
+                      s1 = peg$currPos;
+                      s2 = [];
+                      s3 = peg$parseHTML_Text();
+                      if (s3 !== peg$FAILED) {
+                        while (s3 !== peg$FAILED) {
+                          s2.push(s3);
+                          s3 = peg$parseHTML_Text();
+                        }
+                      } else {
+                        s2 = peg$FAILED;
                       }
-                    } else {
-                      s2 = peg$FAILED;
+                      if (s2 !== peg$FAILED) {
+                        s1 = input.substring(s1, peg$currPos);
+                      } else {
+                        s1 = s2;
+                      }
+                      if (s1 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c1(s1);
+                      }
+                      s0 = s1;
                     }
-                    if (s2 !== peg$FAILED) {
-                      s1 = input.substring(s1, peg$currPos);
-                    } else {
-                      s1 = s2;
-                    }
-                    if (s1 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c1(s1);
-                    }
-                    s0 = s1;
                   }
                 }
               }
@@ -863,6 +879,35 @@
       return s0;
     }
 
+    function peg$parseHTML_Tag_Void() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parseHTML_Tag_Open();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c21(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c22(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
     function peg$parseHTML_Tag_Balanced() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
@@ -879,7 +924,7 @@
           s6 = peg$parseHTML_Tag_Close();
           if (s6 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s7 = peg$c21(s1, s6);
+            s7 = peg$c23(s1, s6);
             if (s7) {
               s7 = void 0;
             } else {
@@ -929,7 +974,7 @@
             s6 = peg$parseHTML_Tag_Close();
             if (s6 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s7 = peg$c21(s1, s6);
+              s7 = peg$c23(s1, s6);
               if (s7) {
                 s7 = void 0;
               } else {
@@ -973,7 +1018,7 @@
           s3 = peg$parseHTML_Tag_Close();
           if (s3 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s4 = peg$c22(s1, s2, s3);
+            s4 = peg$c24(s1, s2, s3);
             if (s4) {
               s4 = void 0;
             } else {
@@ -981,7 +1026,7 @@
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c23(s1, s2, s3);
+              s1 = peg$c25(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1008,11 +1053,11 @@
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c24;
+        s1 = peg$c26;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseHTML_Tag_Name();
@@ -1027,15 +1072,15 @@
             }
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c26;
+                s5 = peg$c28;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                if (peg$silentFails === 0) { peg$fail(peg$c29); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c28(s2, s3);
+                s1 = peg$c30(s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1065,12 +1110,12 @@
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c29) {
-        s1 = peg$c29;
+      if (input.substr(peg$currPos, 2) === peg$c31) {
+        s1 = peg$c31;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseHTML_Tag_Name();
@@ -1083,15 +1128,15 @@
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 62) {
-              s4 = peg$c26;
+              s4 = peg$c28;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c27); }
+              if (peg$silentFails === 0) { peg$fail(peg$c29); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c31(s2);
+              s1 = peg$c33(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1166,7 +1211,7 @@
         s4 = peg$parseHTML_Attribute_Item();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c32(s4);
+          s3 = peg$c34(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1193,7 +1238,7 @@
           s4 = peg$parseHTML_Attribute_Item();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c32(s4);
+            s3 = peg$c34(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1206,7 +1251,7 @@
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c33(s1);
+        s1 = peg$c35(s1);
       }
       s0 = s1;
 
@@ -1234,7 +1279,7 @@
       s1 = peg$parseHTML_Attribute_Name();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c34(s1);
+        s1 = peg$c36(s1);
       }
       s0 = s1;
 
@@ -1255,11 +1300,11 @@
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s3 = peg$c35;
+            s3 = peg$c37;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c36); }
+            if (peg$silentFails === 0) { peg$fail(peg$c38); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -1271,22 +1316,22 @@
             if (s4 !== peg$FAILED) {
               s5 = peg$currPos;
               s6 = [];
-              if (peg$c37.test(input.charAt(peg$currPos))) {
+              if (peg$c39.test(input.charAt(peg$currPos))) {
                 s7 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c38); }
+                if (peg$silentFails === 0) { peg$fail(peg$c40); }
               }
               if (s7 !== peg$FAILED) {
                 while (s7 !== peg$FAILED) {
                   s6.push(s7);
-                  if (peg$c37.test(input.charAt(peg$currPos))) {
+                  if (peg$c39.test(input.charAt(peg$currPos))) {
                     s7 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c38); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c40); }
                   }
                 }
               } else {
@@ -1299,7 +1344,7 @@
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c39(s1, s5);
+                s1 = peg$c41(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1339,11 +1384,11 @@
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s3 = peg$c35;
+            s3 = peg$c37;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c36); }
+            if (peg$silentFails === 0) { peg$fail(peg$c38); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -1354,11 +1399,11 @@
             }
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 34) {
-                s5 = peg$c40;
+                s5 = peg$c42;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                if (peg$silentFails === 0) { peg$fail(peg$c43); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$currPos;
@@ -1367,11 +1412,11 @@
                 s9 = peg$currPos;
                 peg$silentFails++;
                 if (input.charCodeAt(peg$currPos) === 34) {
-                  s10 = peg$c40;
+                  s10 = peg$c42;
                   peg$currPos++;
                 } else {
                   s10 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c43); }
                 }
                 peg$silentFails--;
                 if (s10 === peg$FAILED) {
@@ -1405,11 +1450,11 @@
                   s9 = peg$currPos;
                   peg$silentFails++;
                   if (input.charCodeAt(peg$currPos) === 34) {
-                    s10 = peg$c40;
+                    s10 = peg$c42;
                     peg$currPos++;
                   } else {
                     s10 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c43); }
                   }
                   peg$silentFails--;
                   if (s10 === peg$FAILED) {
@@ -1445,15 +1490,15 @@
                 }
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 34) {
-                    s7 = peg$c40;
+                    s7 = peg$c42;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c41); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c43); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c39(s1, s6);
+                    s1 = peg$c41(s1, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1495,11 +1540,11 @@
           }
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s3 = peg$c35;
+              s3 = peg$c37;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c36); }
+              if (peg$silentFails === 0) { peg$fail(peg$c38); }
             }
             if (s3 !== peg$FAILED) {
               s4 = [];
@@ -1510,11 +1555,11 @@
               }
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 39) {
-                  s5 = peg$c42;
+                  s5 = peg$c44;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c45); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$currPos;
@@ -1523,11 +1568,11 @@
                   s9 = peg$currPos;
                   peg$silentFails++;
                   if (input.charCodeAt(peg$currPos) === 39) {
-                    s10 = peg$c42;
+                    s10 = peg$c44;
                     peg$currPos++;
                   } else {
                     s10 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c45); }
                   }
                   peg$silentFails--;
                   if (s10 === peg$FAILED) {
@@ -1561,11 +1606,11 @@
                     s9 = peg$currPos;
                     peg$silentFails++;
                     if (input.charCodeAt(peg$currPos) === 39) {
-                      s10 = peg$c42;
+                      s10 = peg$c44;
                       peg$currPos++;
                     } else {
                       s10 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c45); }
                     }
                     peg$silentFails--;
                     if (s10 === peg$FAILED) {
@@ -1601,15 +1646,15 @@
                   }
                   if (s6 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 39) {
-                      s7 = peg$c42;
+                      s7 = peg$c44;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c45); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c39(s1, s6);
+                      s1 = peg$c41(s1, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1649,22 +1694,22 @@
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c44.test(input.charAt(peg$currPos))) {
+      if (peg$c46.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c45); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c44.test(input.charAt(peg$currPos))) {
+          if (peg$c46.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c45); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
         }
       } else {
@@ -1693,20 +1738,6 @@
     function peg$parseASCII_Letter() {
       var s0;
 
-      if (peg$c46.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c47); }
-      }
-
-      return s0;
-    }
-
-    function peg$parseASCII_Digit() {
-      var s0;
-
       if (peg$c48.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
@@ -1718,7 +1749,7 @@
       return s0;
     }
 
-    function peg$parseNewline() {
+    function peg$parseASCII_Digit() {
       var s0;
 
       if (peg$c50.test(input.charAt(peg$currPos))) {
@@ -1732,7 +1763,7 @@
       return s0;
     }
 
-    function peg$parse_() {
+    function peg$parseNewline() {
       var s0;
 
       if (peg$c52.test(input.charAt(peg$currPos))) {
@@ -1741,6 +1772,20 @@
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      }
+
+      return s0;
+    }
+
+    function peg$parse_() {
+      var s0;
+
+      if (peg$c54.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
 
       return s0;
@@ -1791,6 +1836,7 @@
           case 'HTML_Tag': return [ [ 'Tag', token.name ], token.attrs, children ];
           case 'HTML_Tag_Close': return [ [ '-Tag', token.name ] ];
           case 'HTML_Tag_Open': return [ [ '+Tag', token.name ], token.attrs ];
+          case 'HTML_Void_Tag': return [ [ 'Tag', token.name ], token.attrs ];
           case 'Text': return token.value;
           case 'WP_Block': return [ [ 'Block', token.blockType ], token.attrs, children ];
           case 'WP_Block_Open': return [ [ '+Block', token.blockType ], token.attrs ];

--- a/src/post.pegjs
+++ b/src/post.pegjs
@@ -26,6 +26,7 @@
       case 'HTML_Tag': return [ [ 'Tag', token.name ], token.attrs, children ];
       case 'HTML_Tag_Close': return [ [ '-Tag', token.name ] ];
       case 'HTML_Tag_Open': return [ [ '+Tag', token.name ], token.attrs ];
+      case 'HTML_Void_Tag': return [ [ 'Tag', token.name ], token.attrs ];
       case 'Text': return token.value;
       case 'WP_Block': return [ [ 'Block', token.blockType ], token.attrs, children ];
       case 'WP_Block_Open': return [ [ '+Block', token.blockType ], token.attrs ];
@@ -44,6 +45,7 @@ Token
   / WP_Block_Start
   / WP_Block_End
   / HTML_Comment
+  / HTML_Tag_Void
   / HTML_Tag_Balanced
   / HTML_Tag_Open
   / HTML_Tag_Close
@@ -87,6 +89,22 @@ HTML_Comment
   { return {
     type: "HTML_Comment",
     innerText: cs.join('')
+  } }
+
+HTML_Tag_Void
+  = t:HTML_Tag_Open
+  & { return undefined !== {
+      'br': true,
+      'col': true,
+      'embed': true,
+      'hr': true,
+      'img': true,
+      'input': true
+    }[ t.name.toLowerCase() ] }
+  { return {
+    type: 'HTML_Void_Tag',
+    name: t.name,
+    attrs: t.attrs
   } }
   
 HTML_Tag_Balanced


### PR DESCRIPTION
Previously `<img>` would have been detected as an `HTML_Tag_Open` but in reality since it can't have any children it is necessarily a complete but empty/void tag.

Now this returns as a complete tag.

cc: @mcsf @mtias @nylen @aduth 